### PR TITLE
Enable base URL to be configurable for OpenAI

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/loader/impl/TextLoader.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/loader/impl/TextLoader.java
@@ -1,0 +1,43 @@
+package org.springframework.ai.loader.impl;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.loader.Loader;
+import org.springframework.ai.splitter.TextSplitter;
+import org.springframework.ai.splitter.TokenTextSplitter;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StreamUtils;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class TextLoader implements Loader {
+
+    private final Resource resource;
+
+    public TextLoader(Resource resource) {
+        Objects.requireNonNull(resource, "The Spring Resource must not be null");
+        this.resource = resource;
+    }
+
+
+    @Override
+    public List<Document> load() {
+        return load(new TokenTextSplitter());
+    }
+
+    @Override
+    public List<Document> load(TextSplitter textSplitter) {
+        try {
+            InputStream inputStream = resource.getInputStream();
+            String doc = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            return textSplitter.apply(Collections.singletonList(new Document(doc)));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+}

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -47,6 +47,12 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>com.squareup.retrofit2</groupId>
+			<artifactId>converter-jackson</artifactId>
+			<version>2.9.0</version>
+		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
@@ -16,7 +16,14 @@
 
 package org.springframework.ai.autoconfigure.openai;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.theokanning.openai.OpenAiApi;
 import com.theokanning.openai.service.OpenAiService;
+
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import org.springframework.ai.autoconfigure.NativeHints;
 import org.springframework.ai.embedding.EmbeddingClient;
@@ -49,7 +56,19 @@ public class OpenAiAutoConfiguration {
 			throw new IllegalArgumentException(
 					"You must provide an API key with the property name " + CONFIG_PREFIX + ".api-key");
 		}
-		return new OpenAiService(openAiProperties.getApiKey(), openAiProperties.getDuration());
+
+		ObjectMapper mapper = OpenAiService.defaultObjectMapper();
+		OkHttpClient client = OpenAiService.defaultClient(openAiProperties.getApiKey(), openAiProperties.getDuration());
+
+		Retrofit retrofit = new Retrofit.Builder().baseUrl(openAiProperties.getBaseUrl())
+			.client(client)
+			.addConverterFactory(JacksonConverterFactory.create(mapper))
+			.addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+			.build();
+
+		OpenAiApi api = retrofit.create(OpenAiApi.class);
+
+		return new OpenAiService(api);
 	}
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiProperties.java
@@ -35,6 +35,8 @@ public class OpenAiProperties {
 
 	private String model = "gpt-3.5-turbo";
 
+	private String baseUrl = "https://api.openai.com";
+
 	public String getApiKey() {
 		return apiKey;
 	}
@@ -65,6 +67,14 @@ public class OpenAiProperties {
 
 	public void setDuration(Duration duration) {
 		this.duration = duration;
+	}
+
+	public String getBaseUrl() {
+		return baseUrl;
+	}
+
+	public void setBaseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
 	}
 
 }


### PR DESCRIPTION
Spring AI currently is fixed on using the official OpenAI URL when working with OpenAI. This makes it impossible to use Spring AI against a locally running OpenAI API such as [LocalAI](https://github.com/go-skynet/LocalAI).

This PR exposes a new property (`spring.ai.openai.base-url`) that allows for custom configuration of the base URL. It still defaults to the official OpenAI API, though. 

For example, to use this with a locally running LocalAI listening on port 8080, the following entry can be added to the application.properties file:

```
spring.ai.openai.base-url=http://localhost:8080/
```
