### PR TITLE
Add TextLoader implementation of Loader

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/loader/impl/TextLoader.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/loader/impl/TextLoader.java
@@ -7,6 +7,7 @@ import org.springframework.ai.splitter.TokenTextSplitter;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -22,7 +23,6 @@ public class TextLoader implements Loader {
         this.resource = resource;
     }
 
-
     @Override
     public List<Document> load() {
         return load(new TokenTextSplitter());
@@ -34,10 +34,9 @@ public class TextLoader implements Loader {
             InputStream inputStream = resource.getInputStream();
             String doc = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
             return textSplitter.apply(Collections.singletonList(new Document(doc)));
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/loader/impl/TextLoader.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/loader/impl/TextLoader.java
@@ -1,0 +1,43 @@
+package org.springframework.ai.loader.impl;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.loader.Loader;
+import org.springframework.ai.splitter.TextSplitter;
+import org.springframework.ai.splitter.TokenTextSplitter;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StreamUtils;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class TextLoader implements Loader {
+
+    private final Resource resource;
+
+    public TextLoader(Resource resource) {
+        Objects.requireNonNull(resource, "The Spring Resource must not be null");
+        this.resource = resource;
+    }
+
+
+    @Override
+    public List<Document> load() {
+        return load(new TokenTextSplitter());
+    }
+
+    @Override
+    public List<Document> load(TextSplitter textSplitter) {
+        try {
+            InputStream inputStream = resource.getInputStream();
+            String doc = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            return textSplitter.apply(Collections.singletonList(new Document(doc)));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
This is an (admittedly somewhat naive) implementation of `Loader` that loads plain text documents. This enables unstructured documents (I tested with board game rules) to be used in embeddings.

Because it was written quickly and with limited understanding of how best to write such a loader, I'm certain that there's a lot of room for improvement. Nonetheless, I'm submitting it for consideration as a starting point for a a better implementation.