### PR TITLE
Add MongoDB as a vector store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
 
 	<packaging>pom</packaging>
 	<url>https://github.com/spring-projects-experimental/spring-ai</url>
-
 	<name>Spring AI</name>
 	<description>Building AI applications with Spring Boot</description>
 
@@ -20,6 +19,7 @@
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-azure-openai</module>
 		<module>spring-ai-docs</module>
 		<module>vector-stores/spring-ai-pgvector-store</module>
+		<module>vector-stores/spring-ai-mongodb-store</module>
 	</modules>
 
     <organization>

--- a/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
@@ -42,12 +42,6 @@ public class Document {
 		this.metadata = metadata;
 	}
 
-	public Document() {
-		this.id = null;
-		this.text = null;
-		this.metadata = null;
-	};
-
 	public String getId() {
 		return id;
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
@@ -42,6 +42,12 @@ public class Document {
 		this.metadata = metadata;
 	}
 
+	public Document() {
+		this.id = null;
+		this.text = null;
+		this.metadata = null;
+	};
+
 	public String getId() {
 		return id;
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/impl/InMemoryVectorStore.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/impl/InMemoryVectorStore.java
@@ -95,6 +95,14 @@ public class InMemoryVectorStore implements VectorStore {
 			this.similarity = similarity;
 		}
 
+		public double getSimilarity() {
+			return similarity;
+		}
+
+		public String getKey() {
+			return key;
+		}
+
 	}
 
 	public class EmbeddingMath {

--- a/vector-stores/spring-ai-mongodb-store/README.md
+++ b/vector-stores/spring-ai-mongodb-store/README.md
@@ -1,0 +1,4 @@
+
+# MongoDB VectorStore
+
+This use mongo db as a vector store using the same math as the in-memory vector store.

--- a/vector-stores/spring-ai-mongodb-store/pom.xml
+++ b/vector-stores/spring-ai-mongodb-store/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.experimental.ai</groupId>
+		<artifactId>spring-ai</artifactId>
+		<version>0.2.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-mongodb-store</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Vector Store - mongodb</name>
+	<description>Spring AI MongoDB Vector Store</description>
+	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects-experimental/spring-ai</url>
+		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<spring-ai.version>0.2.0-SNAPSHOT</spring-ai.version>
+		<!-- testing -->
+		<testcontainers.version>1.19.0</testcontainers.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.experimental.ai</groupId>
+			<artifactId>spring-ai-core</artifactId>
+			<version>${spring-ai.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-mongodb</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-sync</artifactId>
+		</dependency>
+		<!-- TESTING -->
+		<dependency>
+			<groupId>org.springframework.experimental.ai</groupId>
+			<artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+			<version>${spring-ai.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/vector-stores/spring-ai-mongodb-store/src/main/java/org/springframework/ai/vectorstore/MongoDBVectorStore.java
+++ b/vector-stores/spring-ai-mongodb-store/src/main/java/org/springframework/ai/vectorstore/MongoDBVectorStore.java
@@ -21,11 +21,14 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.ai.vectorstore.impl.InMemoryVectorStore;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 /**
  * @author Chris Smith
@@ -75,12 +78,11 @@ public class MongoDBVectorStore implements VectorStore {
 
 	@Override
 	public Optional<Boolean> delete(List<String> idList) {
-		long deleteCount = 0;
-		for (String id : idList) {
-			var deleteRes = mongoTemplate.remove(String.format("{_id: \"%s\"}", id), VECTOR_COLLECTION_NAME);// delete
-			// many
-			deleteCount += deleteRes.getDeletedCount();
-		}
+		Query query = new Query(where("_id").in(idList));
+
+		var deleteRes = mongoTemplate.remove(query, VECTOR_COLLECTION_NAME);
+		long deleteCount = deleteRes.getDeletedCount();
+
 		return Optional.of(deleteCount == idList.size());
 	}
 

--- a/vector-stores/spring-ai-mongodb-store/src/main/java/org/springframework/ai/vectorstore/MongoDBVectorStore.java
+++ b/vector-stores/spring-ai-mongodb-store/src/main/java/org/springframework/ai/vectorstore/MongoDBVectorStore.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore;
+
+import com.mongodb.BasicDBObject;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.vectorstore.impl.InMemoryVectorStore;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author Chris Smith
+ */
+public class MongoDBVectorStore implements VectorStore {
+
+	MongoTemplate mongoTemplate;
+
+	EmbeddingClient embeddingClient;
+
+	private final String VECTOR_COLLECTION_NAME = "vector_store";
+
+	public MongoDBVectorStore(MongoTemplate mongoTemplate, EmbeddingClient embeddingClient) {
+		this.mongoTemplate = mongoTemplate;
+		this.embeddingClient = embeddingClient;
+		if (!mongoTemplate.collectionExists(VECTOR_COLLECTION_NAME)) {
+			mongoTemplate.createCollection(VECTOR_COLLECTION_NAME);
+		}
+	}
+
+	/**
+	 * Maps a basicDBObject to a Spring AI Document
+	 * @param basicDBObject
+	 * @return
+	 */
+	public Document mapBasicDbObject(BasicDBObject basicDBObject) {
+		String id = basicDBObject.getString("_id");
+		String content = basicDBObject.getString("text");
+		Map<String, Object> metadata = (Map<String, Object>) basicDBObject.get("metadata");
+		List<Double> embedding = (List<Double>) basicDBObject.get("embedding");
+
+		Document document = new Document(id, content, metadata);
+		document.setEmbedding(embedding);
+
+		return document;
+	}
+
+	@Override
+	public void add(List<Document> documents) {
+		for (Document document : documents) {
+			List<Double> embedding = this.embeddingClient.embed(document);
+			document.setEmbedding(embedding);
+
+			mongoTemplate.save(document, VECTOR_COLLECTION_NAME);
+		}
+	}
+
+	@Override
+	public Optional<Boolean> delete(List<String> idList) {
+		long deleteCount = 0;
+		for (String id : idList) {
+			var deleteRes = mongoTemplate.remove(String.format("{_id: \"%s\"}", id), VECTOR_COLLECTION_NAME);// delete
+			// many
+			deleteCount += deleteRes.getDeletedCount();
+		}
+		return Optional.of(deleteCount == idList.size());
+	}
+
+	@Override
+	public List<Document> similaritySearch(String query) {
+		return this.similaritySearch(query, 4);
+	}
+
+	@Override
+	public List<Document> similaritySearch(String query, int k) {
+		List<Double> queryEmbedding = this.embeddingClient.embed(query);
+
+		// TODO: explore making this query better
+		return this.mongoTemplate.findAll(BasicDBObject.class, VECTOR_COLLECTION_NAME)
+			.stream()
+			.map(this::mapBasicDbObject)
+			.map(entry -> new InMemoryVectorStore.Similarity(entry.getId(),
+					InMemoryVectorStore.EmbeddingMath.cosineSimilarity(queryEmbedding, entry.getEmbedding())))
+			.sorted(Comparator.<InMemoryVectorStore.Similarity>comparingDouble(s -> s.getSimilarity()).reversed())
+			.limit(k)
+			.map(s -> mongoTemplate.findById(s.getKey(), BasicDBObject.class, VECTOR_COLLECTION_NAME))
+			.map(this::mapBasicDbObject)
+			.toList();
+	}
+
+	@Override
+	public List<Document> similaritySearch(String query, int k, double threshold) {
+		List<Double> queryEmbedding = this.embeddingClient.embed(query);
+
+		return this.mongoTemplate.findAll(BasicDBObject.class, VECTOR_COLLECTION_NAME)
+			.stream()
+			.map(this::mapBasicDbObject)
+			.map(entry -> new InMemoryVectorStore.Similarity(entry.getId(),
+					InMemoryVectorStore.EmbeddingMath.cosineSimilarity(queryEmbedding, entry.getEmbedding())))
+			.filter(s -> s.getSimilarity() >= threshold)
+			.sorted(Comparator.<InMemoryVectorStore.Similarity>comparingDouble(s -> s.getSimilarity()).reversed())
+			.limit(k)
+			.map(s -> mongoTemplate.findById(s.getKey(), BasicDBObject.class, VECTOR_COLLECTION_NAME))
+			.map(this::mapBasicDbObject)
+			.toList();
+	}
+
+}

--- a/vector-stores/spring-ai-mongodb-store/src/main/java/org/springframework/ai/vectorstore/VectorSearchAggregation.java
+++ b/vector-stores/spring-ai-mongodb-store/src/main/java/org/springframework/ai/vectorstore/VectorSearchAggregation.java
@@ -1,0 +1,30 @@
+package org.springframework.ai.vectorstore;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperationContext;
+
+import java.util.List;
+
+class VectorSearchAggregation implements AggregationOperation {
+
+    private final int count;
+    private final List<Double> embeddings;
+
+
+
+    public VectorSearchAggregation(int count, List<Double> embeddings){
+        this.count = count;
+        this.embeddings = embeddings;
+    }
+    @Override
+    public org.bson.Document toDocument(AggregationOperationContext context) {
+       var doc =  new Document("$search",
+                new Document("index", "default")
+                        .append("path", "embedding")
+                        .append("numCandidates", 100)
+                        .append("limit",count)
+                        .append("queryVector", embeddings));
+        return context.getMappedObject(doc);
+    }
+}

--- a/vector-stores/spring-ai-mongodb-store/src/test/java/org/springframework/ai/vectorstore/MongoDBVectorStoreIT.java
+++ b/vector-stores/spring-ai-mongodb-store/src/test/java/org/springframework/ai/vectorstore/MongoDBVectorStoreIT.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore;
+
+import com.mongodb.client.MongoClient;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Chris Smith
+ */
+@Testcontainers
+public class MongoDBVectorStoreIT {
+
+	@Container
+	static GenericContainer<?> mongoContainer = new GenericContainer<>("mongo").withExposedPorts(27017);
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(TestApplication.class)
+		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("SPRING_AI_OPENAI_API_KEY"),
+
+				// JdbcTemplate configuration
+				String.format("spring.data.mongodb.uri=mongodb://localhost:%d/test",
+						mongoContainer.getMappedPort(27017)));
+
+	@Test
+	public void vectorStoreTest() {
+		contextRunner.withConfiguration(AutoConfigurations.of(OpenAiAutoConfiguration.class)).run(context -> {
+
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+
+			List<Document> documents = List.of(
+					new Document(
+							"Spring AI rocks!! Spring AI rocks!! Spring AI rocks!! Spring AI rocks!! Spring AI rocks!!",
+							Collections.singletonMap("meta1", "meta1")),
+					new Document("Hello World Hello World Hello World Hello World Hello World Hello World Hello World"),
+					new Document(
+							"Great Depression Great Depression Great Depression Great Depression Great Depression Great Depression",
+							Collections.singletonMap("meta2", "meta2")));
+
+			vectorStore.add(documents);
+
+			List<Document> results = vectorStore.similaritySearch("Great", 1);
+
+			assertThat(results).hasSize(1);
+			Document resultDoc = results.get(0);
+			assertThat(resultDoc.getId()).isEqualTo(documents.get(2).getId());
+			assertThat(resultDoc.getText()).isEqualTo(
+					"Great Depression Great Depression Great Depression Great Depression Great Depression Great Depression");
+			assertThat(resultDoc.getMetadata().get("meta2")).isEqualTo("meta2");
+
+			// Remove all documents from the store
+			vectorStore.delete(documents.stream().map(doc -> doc.getId()).collect(Collectors.toList()));
+
+			List<Document> results2 = vectorStore.similaritySearch("Great", 1);
+			assertThat(results2).hasSize(0);
+
+		});
+	}
+
+	@Test
+	public void documentUpdateTest() {
+		contextRunner.withConfiguration(AutoConfigurations.of(OpenAiAutoConfiguration.class)).run(context -> {
+
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+
+			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
+					Collections.singletonMap("meta1", "meta1"));
+
+			vectorStore.add(List.of(document));
+
+			List<Document> results = vectorStore.similaritySearch("Spring", 5);
+
+			assertThat(results).hasSize(1);
+			Document resultDoc = results.get(0);
+			assertThat(resultDoc.getId()).isEqualTo(document.getId());
+			assertThat(resultDoc.getText()).isEqualTo("Spring AI rocks!!");
+			assertThat(resultDoc.getMetadata().get("meta1")).isEqualTo("meta1");
+
+			Document sameIdDocument = new Document(document.getId(),
+					"The World is Big and Salvation Lurks Around the Corner",
+					Collections.singletonMap("meta2", "meta2"));
+
+			vectorStore.add(List.of(sameIdDocument));
+
+			results = vectorStore.similaritySearch("FooBar", 5);
+
+			assertThat(results).hasSize(1);
+			resultDoc = results.get(0);
+			assertThat(resultDoc.getId()).isEqualTo(document.getId());
+			assertThat(resultDoc.getText()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
+			assertThat(resultDoc.getMetadata().get("meta2")).isEqualTo("meta2");
+
+		});
+	}
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	public static class TestApplication {
+
+		@Bean
+		public VectorStore vectorStore(MongoTemplate mongoTemplate, EmbeddingClient embeddingClient) {
+			return new MongoDBVectorStore(mongoTemplate, embeddingClient);
+		}
+
+		@Bean
+		public MongoTemplate mongoTemplate(MongoClient mongoClient) {
+			return new MongoTemplate(mongoClient, "test");
+		}
+
+	}
+
+}

--- a/vector-stores/spring-ai-mongodb-store/src/test/java/org/springframework/ai/vectorstore/MongoDBVectorStoreIT.java
+++ b/vector-stores/spring-ai-mongodb-store/src/test/java/org/springframework/ai/vectorstore/MongoDBVectorStoreIT.java
@@ -27,8 +27,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Collections;
@@ -44,16 +42,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 public class MongoDBVectorStoreIT {
 
-	@Container
-	static GenericContainer<?> mongoContainer = new GenericContainer<>("mongo").withExposedPorts(27017);
+	//static GenericContainer<?> mongoContainer = new GenericContainer<>("mongo").withExposedPorts(27017);
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withUserConfiguration(TestApplication.class)
 		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("SPRING_AI_OPENAI_API_KEY"),
 
 				// JdbcTemplate configuration
-				String.format("spring.data.mongodb.uri=mongodb://localhost:%d/test",
-						mongoContainer.getMappedPort(27017)));
+				String.format("spring.data.mongodb.uri=mongodb://localhost:%d/test"));
+
 
 	@Test
 	public void vectorStoreTest() {

--- a/vector-stores/spring-ai-mongodb-store/src/test/java/org/springframework/ai/vectorstore/MongoDBVectorStoreIT.java
+++ b/vector-stores/spring-ai-mongodb-store/src/test/java/org/springframework/ai/vectorstore/MongoDBVectorStoreIT.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.vectorstore;
 
 import com.mongodb.client.MongoClient;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.document.Document;
@@ -34,7 +33,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
Adding MongoDB as a vector store.

Implemented using basically the same logic and math as `InMemoryVectorStore` so it's prob worth breaking some of those shared classes out.

Big thanks to @tzolov for the work on `pgvector-store`, I was able to use most of his tests as guidance
