### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
@@ -52,7 +52,7 @@ public class OpenAiAutoConfiguration {
 
 	@Bean
 	public OpenAiService theoOpenAiService(OpenAiProperties openAiProperties) {
-		if (openAiProperties.getBaseUrl().equals("https://api.openai.com")) {
+		if ("https://api.openai.com".equals(openAiProperties.getBaseUrl())) {
 			if (!StringUtils.hasText(openAiProperties.getApiKey())) {
 				throw new IllegalArgumentException(
 						"You must provide an API key with the property name " + CONFIG_PREFIX + ".api-key");


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Czcarroll4%2Fspring-ai%7C87123cd25a0b9741818a4732b100ed2519e2117c)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->