### PR TITLE
Refactor find the last punctuation mark

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/splitter/PunctuationMark.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/splitter/PunctuationMark.java
@@ -1,0 +1,23 @@
+package org.springframework.ai.splitter;
+
+import java.util.Arrays;
+
+public enum PunctuationMark {
+    PERIOD('.'),
+    QUESTION_MARK('?'),
+    EXCLAMATION_MARK('!'),
+    SINGLE_QUOTATION('\''),
+    DOUBLE_QUOTATION('\"'),
+    LINE_BREAK('\n');
+
+    private final char mark;
+
+    PunctuationMark(char mark) {
+        this.mark = mark;
+    }
+
+    public static Boolean first(char character){
+        return Arrays.stream(PunctuationMark.values())
+                     .anyMatch(punctuation -> punctuation.mark  == character);
+    }
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/splitter/TokenTextSplitter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/splitter/TokenTextSplitter.java
@@ -61,8 +61,7 @@ public class TokenTextSplitter extends TextSplitter {
 			}
 
 			// Find the last period or punctuation mark in the chunk
-			int lastPunctuation = Math.max(chunkText.lastIndexOf('.'), Math.max(chunkText.lastIndexOf('?'),
-					Math.max(chunkText.lastIndexOf('!'), chunkText.lastIndexOf('\n'))));
+			int lastPunctuation = getLastPunctuation(chunkText);
 
 			if (lastPunctuation != -1 && lastPunctuation > minChunkSizeChars) {
 				// Truncate the chunk text at the punctuation mark
@@ -89,6 +88,18 @@ public class TokenTextSplitter extends TextSplitter {
 		}
 
 		return chunks;
+	}
+
+	private static int getLastPunctuation(String chunkText) {
+		int lastPunctuation = 0;
+		char[] chunkTextCharacters = chunkText.toCharArray();
+		for (int i = chunkText.length(); i --> 0;) {
+			if(PunctuationMark.first(chunkTextCharacters[i])){
+				lastPunctuation = i;
+				break;
+			}
+		}
+		return lastPunctuation;
 	}
 
 	private List<Integer> getEncodedTokens(String text) {


### PR DESCRIPTION
When truncating the token, we need to find the last punctuation mark. But in our current code, we're looping over each punctuation mark. If it can't find that punctuation mark, it will loop the length of the chunkText. I added something to define the punctuation as an enum and terminate the loop as soon as that punctuation is found. 

Thanks.