### PR TITLE
Simplify logic in `AiClient`, `Prompt` and `Message` types

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/client/AiClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/client/AiClient.java
@@ -24,7 +24,7 @@ public interface AiClient {
 
 	default String generate(String message) {
 		Prompt prompt = new Prompt(new UserMessage(message));
-		return generate(prompt).getGenerations().get(0).getText();
+		return generate(prompt).getGeneration().getText();
 	}
 
 	AiResponse generate(Prompt prompt);

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/Prompt.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/Prompt.java
@@ -24,14 +24,14 @@ import java.util.List;
 
 public class Prompt {
 
-	private List<Message> messages;
+	private final List<Message> messages;
 
 	public Prompt(String contents) {
-		this.messages = Collections.singletonList(new UserMessage(contents));
+		this(new UserMessage(contents));
 	}
 
 	public Prompt(Message message) {
-		this.messages = Collections.singletonList(message);
+		this(Collections.singletonList(message));
 	}
 
 	public Prompt(List<Message> messages) {
@@ -40,7 +40,7 @@ public class Prompt {
 
 	public String getContents() {
 		StringBuilder sb = new StringBuilder();
-		for (Message message : messages) {
+		for (Message message : getMessages()) {
 			sb.append(message.getContent());
 		}
 		return sb.toString();

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
@@ -22,6 +22,7 @@ import org.springframework.util.StreamUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,8 +42,7 @@ public abstract class AbstractMessage implements Message {
 	}
 
 	protected AbstractMessage(MessageType messageType, String content) {
-		this.messageType = messageType;
-		this.content = content;
+		this(messageType, content, Collections.emptyMap());
 	}
 
 	protected AbstractMessage(MessageType messageType, String content, Map<String, Object> messageProperties) {
@@ -52,13 +52,7 @@ public abstract class AbstractMessage implements Message {
 	}
 
 	protected AbstractMessage(MessageType messageType, Resource resource) {
-		this.messageType = messageType;
-		try (InputStream inputStream = resource.getInputStream()) {
-			this.content = StreamUtils.copyToString(inputStream, Charset.defaultCharset());
-		}
-		catch (IOException ex) {
-			throw new RuntimeException("Failed to read resource", ex);
-		}
+		this(messageType, resource, Collections.emptyMap());
 	}
 
 	protected AbstractMessage(MessageType messageType, Resource resource, Map<String, Object> messageProperties) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/ChatMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/ChatMessage.java
@@ -21,14 +21,11 @@ import java.util.Map;
 public class ChatMessage extends AbstractMessage {
 
 	public ChatMessage(String role, String content) {
-		this.messageType = MessageType.valueOf(role);
-		this.content = content;
+		super(MessageType.valueOf(role), content);
 	}
 
 	public ChatMessage(String role, String content, Map<String, Object> properties) {
-		this.messageType = MessageType.valueOf(role);
-		this.content = content;
-		this.properties = properties;
+		super(MessageType.valueOf(role), content, properties);
 	}
 
 	public ChatMessage(MessageType messageType, String content) {

--- a/spring-ai-core/src/test/java/org/springframework/ai/client/AiClientTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/client/AiClientTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.prompt.Prompt;
+
+/**
+ * Unit Tests for {@link AiClient}.
+ *
+ * @author John Blum
+ * @since 0.2.0
+ */
+class AiClientTests {
+
+	@Test
+	void generateWithStringCallsGenerateWithPromptAndReturnsResponseCorrectly() {
+
+		String userMessage = "Zero Wing";
+		String responseMessage = "All your bases are belong to us";
+
+		AiClient mockClient = mock(AiClient.class);
+		Generation generation = spy(new Generation(responseMessage));
+		AiResponse response = spy(new AiResponse(Collections.singletonList(generation)));
+
+		doCallRealMethod().when(mockClient).generate(anyString());
+
+		doAnswer(invocationOnMock -> {
+
+			Prompt prompt = invocationOnMock.getArgument(0);
+
+			assertThat(prompt).isNotNull();
+			assertThat(prompt.getContents()).isEqualTo(userMessage);
+
+			return response;
+
+		}).when(mockClient).generate(any(Prompt.class));
+
+		assertThat(mockClient.generate(userMessage)).isEqualTo(responseMessage);
+
+		verify(mockClient, times(1)).generate(eq(userMessage));
+		verify(mockClient, times(1)).generate(isA(Prompt.class));
+		verify(response, times(1)).getGeneration();
+		verify(generation, times(1)).getText();
+		verifyNoMoreInteractions(mockClient, generation, response);
+	}
+
+}


### PR DESCRIPTION
Simplify constructors in Prompt and Message subclasses.

Change Generation access from AiResponse in AiCilent.generate(:String).

Include unit tests for AiClient.

Cleanup compiler warnings.
