### PR TITLE
Add spring-test project - NOTE: java version issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 		<module>spring-ai-core</module>
 		<module>spring-ai-openai</module>
 		<module>spring-ai-azure-openai</module>
+		<module>spring-ai-test</module>
 		<module>spring-ai-spring-boot-autoconfigure</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-openai</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-azure-openai</module>

--- a/spring-ai-core/src/main/java/org/springframework/ai/parser/BeanOutputParser.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/parser/BeanOutputParser.java
@@ -88,7 +88,6 @@ public class BeanOutputParser<T> implements OutputParser<T> {
 
 	@Override
 	public String getFormat() {
-
 		String raw = """
 				Your response should be in JSON format.
 				Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.

--- a/spring-ai-openai/src/test/java/org/springframework/ai/openai/client/ClientIT.java
+++ b/spring-ai-openai/src/test/java/org/springframework/ai/openai/client/ClientIT.java
@@ -55,7 +55,7 @@ class ClientIT extends AbstractIT {
 		PromptTemplate promptTemplate = new PromptTemplate(template,
 				Map.of("subject", "ice cream flavors", "format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = openAiClient.generate(prompt).getGeneration();
+		Generation generation = this.openAiClient.generate(prompt).getGeneration();
 
 		List<String> list = outputParser.parse(generation.getText());
 		System.out.println(list);

--- a/spring-ai-test/pom.xml
+++ b/spring-ai-test/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.experimental.ai</groupId>
+		<artifactId>spring-ai</artifactId>
+		<version>0.2.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-ai-test</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Test</name>
+	<description>Test support for AI programming</description>
+	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects-experimental/spring-ai</url>
+		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.experimental.ai</groupId>
+			<artifactId>spring-ai-openai</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+		</dependency>
+
+<!--		&lt;!&ndash; test dependencies &ndash;&gt;-->
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-test</artifactId>-->
+<!--			<scope>test</scope>-->
+<!--		</dependency>-->
+
+	</dependencies>
+
+</project>

--- a/spring-ai-test/src/main/java/org/springframework/ai/evaluation/AbstractEvaluationTest.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/evaluation/AbstractEvaluationTest.java
@@ -1,4 +1,4 @@
-package org.springframework.ai.openai.testutils;
+package org.springframework.ai.evaluation;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,23 +18,23 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public abstract class AbstractIT {
+public class AbstractEvaluationTest {
 
-	private static final Logger logger = LoggerFactory.getLogger(AbstractIT.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractEvaluationTest.class);
 
 	@Autowired
 	protected AiClient openAiClient;
 
-	@Value("classpath:/prompts/eval/qa-evaluator-accurate-answer.st")
+	@Value("classpath:/prompts/spring/test/evaluation/qa-evaluator-accurate-answer.st")
 	protected Resource qaEvaluatorAccurateAnswerResource;
 
-	@Value("classpath:/prompts/eval/qa-evaluator-not-related-message.st")
+	@Value("classpath:/prompts/spring/test/evaluation/qa-evaluator-not-related-message.st")
 	protected Resource qaEvaluatorNotRelatedResource;
 
-	@Value("classpath:/prompts/eval/qa-evaluator-fact-based-answer.st")
+	@Value("classpath:/prompts/spring/test/evaluation/qa-evaluator-fact-based-answer.st")
 	protected Resource qaEvalutaorFactBasedAnswerResource;
 
-	@Value("classpath:/prompts/eval/user-evaluator-message.st")
+	@Value("classpath:/prompts/spring/test/evaluation/user-evaluator-message.st")
 	protected Resource userEvaluatorResource;
 
 	protected void evaluateQuestionAndAnswer(String question, AiResponse response, boolean factBased) {

--- a/spring-ai-test/src/main/resources/prompts/spring/test/evaluation/qa-evaluator-accurate-answer.st
+++ b/spring-ai-test/src/main/resources/prompts/spring/test/evaluation/qa-evaluator-accurate-answer.st
@@ -1,0 +1,3 @@
+You are an AI assistant who helps users to evaluate if the answers to questions are accurate.
+You will be provided with a QUESTION and an ANSWER.
+Your goal is to evaluate the QUESTION and ANSWER and reply with a YES or NO answer.

--- a/spring-ai-test/src/main/resources/prompts/spring/test/evaluation/qa-evaluator-fact-based-answer.st
+++ b/spring-ai-test/src/main/resources/prompts/spring/test/evaluation/qa-evaluator-fact-based-answer.st
@@ -1,0 +1,7 @@
+You are an AI evaluator. Your task is to verify if the provided ANSWER is a direct and accurate response to the given QUESTION. If the ANSWER is correct and directly answers the QUESTION, reply with "YES". If the ANSWER is not a direct response or is inaccurate, reply with "NO".
+
+For example:
+
+If the QUESTION is "What is the capital of France?" and the ANSWER is "Paris.", you should respond with "YES".
+If the QUESTION is "What is the capital of France?" and the ANSWER is "France is in Europe.", respond with "NO".
+Now, evaluate the following:

--- a/spring-ai-test/src/main/resources/prompts/spring/test/evaluation/qa-evaluator-not-related-message.st
+++ b/spring-ai-test/src/main/resources/prompts/spring/test/evaluation/qa-evaluator-not-related-message.st
@@ -1,0 +1,4 @@
+You are an AI assistant who helps users to evaluate if the answers to questions are accurate.
+You will be provided with a QUESTION and an ANSWER.
+A previous evaluation has determined that QUESTION and ANSWER are not related.
+Give an explanation as to why they are not related.

--- a/spring-ai-test/src/main/resources/prompts/spring/test/evaluation/user-evaluator-message.st
+++ b/spring-ai-test/src/main/resources/prompts/spring/test/evaluation/user-evaluator-message.st
@@ -1,0 +1,6 @@
+The question and answer to evaluate are:
+
+QUESTION: ```{question}```
+
+ANSWER: ```{answer}```
+


### PR DESCRIPTION
not sure why it produces this error

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project spring-ai-test: Compilation failure: Compilation failure: 
[ERROR] Source option 5 is no longer supported. Use 7 or later.
[ERROR] Target option 5 is no longer supported. Use 7 or later.
[ERROR] -> [Help 1]
```
