### PR TITLE
Make DocumentReader stateless; pass resource to be read at read time

### DIFF
--- a/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
+++ b/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
@@ -35,19 +35,18 @@ public class PagePdfDocumentReaderTests {
 	@Test
 	public void test1() {
 
-		PagePdfDocumentReader pdfReader = new PagePdfDocumentReader("classpath:/sample1.pdf",
-				PdfDocumentReaderConfig.builder()
-					.withPageTopMargin(0)
-					.withPageBottomMargin(0)
-					.withPageExtractedTextFormatter(PageExtractedTextFormatter.builder()
-						.withNumberOfTopTextLinesToDelete(0)
-						.withNumberOfBottomTextLinesToDelete(3)
-						.withNumberOfTopPagesToSkipBeforeDelete(0)
-						.build())
-					.withPagesPerDocument(1)
-					.build());
+		PagePdfDocumentReader pdfReader = new PagePdfDocumentReader(PdfDocumentReaderConfig.builder()
+			.withPageTopMargin(0)
+			.withPageBottomMargin(0)
+			.withPageExtractedTextFormatter(PageExtractedTextFormatter.builder()
+				.withNumberOfTopTextLinesToDelete(0)
+				.withNumberOfBottomTextLinesToDelete(3)
+				.withNumberOfTopPagesToSkipBeforeDelete(0)
+				.build())
+			.withPagesPerDocument(1)
+			.build());
 
-		List<Document> docs = pdfReader.get();
+		List<Document> docs = pdfReader.read("classpath:/sample1.pdf");
 
 		assertThat(docs).hasSize(4);
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/document/DocumentReader.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/DocumentReader.java
@@ -1,8 +1,13 @@
 package org.springframework.ai.document;
 
 import java.util.List;
-import java.util.function.Supplier;
 
-public interface DocumentReader extends Supplier<List<Document>> {
+import org.springframework.core.io.Resource;
+
+public interface DocumentReader {
+
+	List<Document> read(String resourceUrl);
+
+	List<Document> read(Resource resource);
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/reader/JsonReader.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/reader/JsonReader.java
@@ -11,11 +11,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentReader;
+import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 
 public class JsonReader implements DocumentReader {
-
-	private Resource resource;
 
 	private JsonMetadataGenerator jsonMetadataGenerator;
 
@@ -25,29 +24,31 @@ public class JsonReader implements DocumentReader {
 	private List<String> jsonKeysToUse;
 
 	public JsonReader(Resource resource) {
-		this(resource, new ArrayList<>().toArray(new String[0]));
+		this(new ArrayList<>().toArray(new String[0]));
 	}
 
-	public JsonReader(Resource resource, String... jsonKeysToUse) {
-		this(resource, new EmptyJsonMetadataGenerator(), jsonKeysToUse);
+	public JsonReader(String... jsonKeysToUse) {
+		this(new EmptyJsonMetadataGenerator(), jsonKeysToUse);
 	}
 
-	public JsonReader(Resource resource, JsonMetadataGenerator jsonMetadataGenerator, String... jsonKeysToUse) {
+	public JsonReader(JsonMetadataGenerator jsonMetadataGenerator, String... jsonKeysToUse) {
 		Objects.requireNonNull(jsonKeysToUse, "keys must not be null");
 		Objects.requireNonNull(jsonMetadataGenerator, "jsonMetadataGenerator must not be null");
-		Objects.requireNonNull(resource, "The Spring Resource must not be null");
-		this.resource = resource;
 		this.jsonMetadataGenerator = jsonMetadataGenerator;
 		this.jsonKeysToUse = List.of(jsonKeysToUse);
 	}
 
+	public List<Document> read(String resourceUrl) {
+		return read(new DefaultResourceLoader().getResource(resourceUrl));
+	}
+
 	@Override
-	public List<Document> get() {
+	public List<Document> read(Resource resource) {
 		ObjectMapper objectMapper = new ObjectMapper();
 		List<Document> documents = new ArrayList<>();
 		try {
 			// TODO, not all json will be an array
-			List<Map<String, Object>> jsonData = objectMapper.readValue(this.resource.getInputStream(),
+			List<Map<String, Object>> jsonData = objectMapper.readValue(resource.getInputStream(),
 					new TypeReference<List<Map<String, Object>>>() {
 					});
 			for (Map<String, Object> item : jsonData) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/reader/TextReader.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/reader/TextReader.java
@@ -25,25 +25,11 @@ public class TextReader implements DocumentReader {
 	public static final String SOURCE_METADATA = "source";
 
 	/**
-	 * Input resource to load the text from.
-	 */
-	private final Resource resource;
-
-	/**
 	 * @return Character set to be used when loading data from the
 	 */
 	private Charset charset = StandardCharsets.UTF_8;
 
 	private Map<String, Object> customMetadata = new HashMap<>();
-
-	public TextReader(String resourceUrl) {
-		this(new DefaultResourceLoader().getResource(resourceUrl));
-	}
-
-	public TextReader(Resource resource) {
-		Objects.requireNonNull(resource, "The Spring Resource must not be null");
-		this.resource = resource;
-	}
 
 	public void setCharset(Charset charset) {
 		Objects.requireNonNull(charset, "The charset must not be null");
@@ -63,14 +49,19 @@ public class TextReader implements DocumentReader {
 	}
 
 	@Override
-	public List<Document> get() {
+	public List<Document> read(String resourceUrl) {
+		return read(new DefaultResourceLoader().getResource(resourceUrl));
+	}
+
+	@Override
+	public List<Document> read(Resource resource) {
 		try {
 
-			String document = StreamUtils.copyToString(this.resource.getInputStream(), this.charset);
+			String document = StreamUtils.copyToString(resource.getInputStream(), this.charset);
 
 			// Inject source information as a metadata.
 			this.customMetadata.put(CHARSET_METADATA, this.charset.name());
-			this.customMetadata.put(SOURCE_METADATA, this.resource.getFilename());
+			this.customMetadata.put(SOURCE_METADATA, resource.getFilename());
 
 			return List.of(new Document(document, this.customMetadata));
 			// return textSplitter.apply(Collections.singletonList(new Document(document,

--- a/spring-ai-core/src/test/java/org/springframework/ai/reader/JsonReaderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/reader/JsonReaderTests.java
@@ -18,7 +18,6 @@ package org.springframework.ai.reader;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.document.Document;
-import org.springframework.ai.reader.JsonReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
@@ -36,8 +35,8 @@ public class JsonReaderTests {
 	@Test
 	void loadJson() {
 		assertThat(resource).isNotNull();
-		JsonReader jsonReader = new JsonReader(resource, "description");
-		List<Document> documents = jsonReader.get();
+		JsonReader jsonReader = new JsonReader("description");
+		List<Document> documents = jsonReader.read(resource);
 		assertThat(documents).isNotEmpty();
 		for (Document document : documents) {
 			assertThat(document.getContent()).isNotEmpty();

--- a/spring-ai-core/src/test/java/org/springframework/ai/reader/TextReaderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/reader/TextReaderTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Craig Walls
  */
 public class TextReaderTests {
 
@@ -37,10 +38,10 @@ public class TextReaderTests {
 	@Test
 	void loadText() {
 		assertThat(resource).isNotNull();
-		TextReader textReader = new TextReader(resource);
+		TextReader textReader = new TextReader();
 		textReader.getCustomMetadata().put("customKey", "Value");
 
-		List<Document> documents0 = textReader.get();
+		List<Document> documents0 = textReader.read(resource);
 
 		List<Document> documents = new TokenTextSplitter().apply(documents0);
 

--- a/spring-ai-openai/src/test/java/org/springframework/ai/openai/acme/AcmeIT.java
+++ b/spring-ai-openai/src/test/java/org/springframework/ai/openai/acme/AcmeIT.java
@@ -56,7 +56,7 @@ public class AcmeIT extends AbstractIT {
 	void acmeChain() {
 
 		// Step 1 - load documents
-		JsonReader jsonReader = new JsonReader(bikesResource, "name", "price", "shortDescription", "description");
+		JsonReader jsonReader = new JsonReader("name", "price", "shortDescription", "description");
 
 		var textSplitter = new TokenTextSplitter();
 
@@ -65,7 +65,7 @@ public class AcmeIT extends AbstractIT {
 		logger.info("Creating Embeddings...");
 		VectorStore vectorStore = new InMemoryVectorStore(embeddingClient);
 
-		vectorStore.accept(textSplitter.apply(jsonReader.get()));
+		vectorStore.accept(textSplitter.apply(jsonReader.read(bikesResource)));
 
 		// Now user query
 

--- a/spring-ai-openai/src/test/java/org/springframework/ai/openai/vectorstore/SimplePersistentVectorStoreIT.java
+++ b/spring-ai-openai/src/test/java/org/springframework/ai/openai/vectorstore/SimplePersistentVectorStoreIT.java
@@ -31,9 +31,9 @@ public class SimplePersistentVectorStoreIT {
 
 	@Test
 	void persist(@TempDir(cleanup = CleanupMode.ON_SUCCESS) Path workingDir) {
-		JsonReader jsonReader = new JsonReader(bikesJsonResource, new ProductMetadataGenerator(), "price", "name",
-				"shortDescription", "description", "tags");
-		List<Document> documents = jsonReader.get();
+		JsonReader jsonReader = new JsonReader(new ProductMetadataGenerator(), "price", "name", "shortDescription",
+				"description", "tags");
+		List<Document> documents = jsonReader.read(bikesJsonResource);
 		SimplePersistentVectorStore vectorStore = new SimplePersistentVectorStore(this.embeddingClient);
 		vectorStore.add(documents);
 


### PR DESCRIPTION
Per the discussion in Slack (https://vmware.slack.com/archives/C058EAJEBU1/p1698410369053209), I've changed `DocumentReader` such that:

- No longer implements `Supplier`
- Renamed `get()` to `read()` (with 2 overloaded implementations)
- No longer requires a `Resource` (or URL string) at construction time.
- Defer provision of `Resource` or URL string to `read()` invocation. 

This allows the reader to be configured once as a bean in the Spring application context and then injected and used as many times as you'd like to read multiple documents (as opposed to creating a new instance for every document to be read).
