### PR TITLE
Simple AiChain implementation to format prompt and submit to AiClient

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chain/AbstractChain.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chain/AbstractChain.java
@@ -34,6 +34,13 @@ public abstract class AbstractChain implements Chain {
 	}
 
 	@Override
+	public String apply(Map<String, Object> input) {
+		AiInput aiInput = new AiInput(input);
+		AiOutput aiOutput = apply(aiInput);
+		return aiOutput.getOutputData().get(getOutputKeys().get(0)).toString();
+	}
+
+	@Override
 	public AiInput preProcess(AiInput aiInput) {
 		validateInputs(aiInput.getInputData());
 		return aiInput;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chain/AiChain.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chain/AiChain.java
@@ -25,7 +25,6 @@ public class AiChain extends AbstractChain {
 
 	/**
 	 * Constructs an AiChain.
-	 *
 	 * @param aiClient The AI client to use to generate the response
 	 * @param promptTemplate The prompt template to use to render the prompt
 	 * @param outputKey The key to use for the output data when rendered into an AiOutput

--- a/spring-ai-core/src/main/java/org/springframework/ai/chain/AiChain.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chain/AiChain.java
@@ -8,7 +8,7 @@ import org.springframework.ai.prompt.PromptTemplate;
 import java.util.List;
 import java.util.Map;
 
-public class LLMChain extends AbstractChain {
+public class AiChain extends AbstractChain {
 
 	private final AiClient aiClient;
 
@@ -18,7 +18,7 @@ public class LLMChain extends AbstractChain {
 
 	private final OutputParser outputParser;
 
-	public LLMChain(AiClient aiClient, PromptTemplate promptTemplate, String outputKey, OutputParser outputParser) {
+	public AiChain(AiClient aiClient, PromptTemplate promptTemplate, String outputKey, OutputParser outputParser) {
 		this.aiClient = aiClient;
 		this.promptTemplate = promptTemplate;
 		this.outputKey = outputKey;
@@ -27,8 +27,7 @@ public class LLMChain extends AbstractChain {
 
 	@Override
 	public List<String> getInputKeys() {
-		return List.of(); // TODO : What are these? In LangChain, they come from the
-							// prompt template.
+		return promptTemplate.getInputVariables().stream().toList();
 	}
 
 	@Override
@@ -39,7 +38,14 @@ public class LLMChain extends AbstractChain {
 	@Override
 	protected AiOutput doApply(AiInput aiInput) {
 		Prompt prompt = promptTemplate.create(aiInput.getInputData());
-		return new AiOutput(Map.of(outputKey, aiClient.generate(prompt)));
+		return new AiOutput(Map.of(outputKey, aiClient.generate(prompt).getGeneration().getText())); // TODO:
+																										// Getting
+																										// the
+																										// text,
+																										// not
+																										// the
+																										// right
+																										// thing
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chain/AiChain.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chain/AiChain.java
@@ -8,6 +8,11 @@ import org.springframework.ai.prompt.PromptTemplate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Simple chain that renders a prompt from a prompt template and generates a response.
+ *
+ * @author Craig Walls
+ */
 public class AiChain extends AbstractChain {
 
 	private final AiClient aiClient;
@@ -18,6 +23,14 @@ public class AiChain extends AbstractChain {
 
 	private final OutputParser outputParser;
 
+	/**
+	 * Constructs an AiChain.
+	 *
+	 * @param aiClient The AI client to use to generate the response
+	 * @param promptTemplate The prompt template to use to render the prompt
+	 * @param outputKey The key to use for the output data when rendered into an AiOutput
+	 * @param outputParser The output parser to use to parse the response
+	 */
 	public AiChain(AiClient aiClient, PromptTemplate promptTemplate, String outputKey, OutputParser outputParser) {
 		this.aiClient = aiClient;
 		this.promptTemplate = promptTemplate;
@@ -25,27 +38,34 @@ public class AiChain extends AbstractChain {
 		this.outputParser = outputParser;
 	}
 
+	/**
+	 * Returns the input keys that the prompt template requires.
+	 * @return the input keys that the prompt template requires.
+	 */
 	@Override
 	public List<String> getInputKeys() {
 		return promptTemplate.getInputVariables().stream().toList();
 	}
 
+	/**
+	 * Returns the output keys that the output parser will produce.
+	 * @return the output keys that the output parser will produce.
+	 */
 	@Override
 	public List<String> getOutputKeys() {
 		return List.of(outputKey);
 	}
 
+	/**
+	 * Renders a prompt from the prompt template and generates a response.
+	 * @param aiInput The input data to use to render the prompt
+	 * @return an AiOutput containing the generated response
+	 */
 	@Override
 	protected AiOutput doApply(AiInput aiInput) {
 		Prompt prompt = promptTemplate.create(aiInput.getInputData());
-		return new AiOutput(Map.of(outputKey, aiClient.generate(prompt).getGeneration().getText())); // TODO:
-																										// Getting
-																										// the
-																										// text,
-																										// not
-																										// the
-																										// right
-																										// thing
+		String generationText = aiClient.generate(prompt).getGeneration().getText();
+		return new AiOutput(Map.of(outputKey, outputParser.parse(generationText)));
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chain/AiOutput.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chain/AiOutput.java
@@ -10,7 +10,7 @@ public class AiOutput {
 		this.outputData = outputData;
 	}
 
-	Map<String, Object> getOutputData() {
+	public Map<String, Object> getOutputData() {
 		return this.outputData;
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chain/Chain.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chain/Chain.java
@@ -10,6 +10,8 @@ public interface Chain extends Function<AiInput, AiOutput> {
 
 	List<String> getOutputKeys();
 
+	String apply(Map<String, Object> input);
+
 	AiInput preProcess(AiInput aiInput);
 
 	Map<String, Object> postProcess(AiInput aiInput, AiOutput aiOutput);

--- a/spring-ai-core/src/main/java/org/springframework/ai/chain/LLMChain.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chain/LLMChain.java
@@ -1,0 +1,45 @@
+package org.springframework.ai.chain;
+
+import org.springframework.ai.client.AiClient;
+import org.springframework.ai.parser.OutputParser;
+import org.springframework.ai.prompt.Prompt;
+import org.springframework.ai.prompt.PromptTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+public class LLMChain extends AbstractChain {
+
+	private final AiClient aiClient;
+
+	private final PromptTemplate promptTemplate;
+
+	private final String outputKey;
+
+	private final OutputParser outputParser;
+
+	public LLMChain(AiClient aiClient, PromptTemplate promptTemplate, String outputKey, OutputParser outputParser) {
+		this.aiClient = aiClient;
+		this.promptTemplate = promptTemplate;
+		this.outputKey = outputKey;
+		this.outputParser = outputParser;
+	}
+
+	@Override
+	public List<String> getInputKeys() {
+		return List.of(); // TODO : What are these? In LangChain, they come from the
+							// prompt template.
+	}
+
+	@Override
+	public List<String> getOutputKeys() {
+		return List.of(outputKey);
+	}
+
+	@Override
+	protected AiOutput doApply(AiInput aiInput) {
+		Prompt prompt = promptTemplate.create(aiInput.getInputData());
+		return new AiOutput(Map.of(outputKey, aiClient.generate(prompt)));
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/parser/StringOutputParser.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/parser/StringOutputParser.java
@@ -4,25 +4,25 @@ import org.springframework.core.convert.support.DefaultConversionService;
 
 public class StringOutputParser extends AbstractConversionServiceOutputParser<String> {
 
-        public StringOutputParser() {
-                this(new DefaultConversionService());
-        }
+	public StringOutputParser() {
+		this(new DefaultConversionService());
+	}
 
-        public StringOutputParser(DefaultConversionService conversionService) {
-                super(conversionService);
-        }
+	public StringOutputParser(DefaultConversionService conversionService) {
+		super(conversionService);
+	}
 
-    @Override
-    public String getFormat() {
-        return """
-                Your response should be a string
-                eg: `foo`
-                """;
-    }
+	@Override
+	public String getFormat() {
+		return """
+				Your response should be a string
+				eg: `foo`
+				""";
+	}
 
-    @Override
-    public String parse(String text) {
-        return getConversionService().convert(text, String.class);
-    }
+	@Override
+	public String parse(String text) {
+		return getConversionService().convert(text, String.class);
+	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/parser/StringOutputParser.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/parser/StringOutputParser.java
@@ -1,0 +1,28 @@
+package org.springframework.ai.parser;
+
+import org.springframework.core.convert.support.DefaultConversionService;
+
+public class StringOutputParser extends AbstractConversionServiceOutputParser<String> {
+
+        public StringOutputParser() {
+                this(new DefaultConversionService());
+        }
+
+        public StringOutputParser(DefaultConversionService conversionService) {
+                super(conversionService);
+        }
+
+    @Override
+    public String getFormat() {
+        return """
+                Your response should be a string
+                eg: `foo`
+                """;
+    }
+
+    @Override
+    public String parse(String text) {
+        return getConversionService().convert(text, String.class);
+    }
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/Prompt.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/Prompt.java
@@ -55,4 +55,14 @@ public class Prompt {
 		return "Prompt{" + "messages=" + messages + '}';
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		return (this == other || (other instanceof Prompt && this.messages.equals(((Prompt) other).messages)));
+	}
+
+	@Override
+	public int hashCode() {
+		return this.messages.hashCode();
+	}
+
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/PromptTemplate.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/PromptTemplate.java
@@ -179,7 +179,7 @@ public class PromptTemplate
 		return new Prompt(render(model));
 	}
 
-	protected Set<String> getInputVariables() {
+	public Set<String> getInputVariables() {
 		TokenStream tokens = this.st.impl.tokens;
 		return IntStream.range(0, tokens.range())
 			.mapToObj(tokens::get)

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class AbstractMessage implements Message {
 
@@ -86,4 +87,16 @@ public abstract class AbstractMessage implements Message {
 		return this.messageType.getValue();
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		AbstractMessage that = (AbstractMessage) o;
+		return Objects.equals(content, that.content) && Objects.equals(properties, that.properties) && messageType == that.messageType;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(content, properties, messageType);
+	}
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
@@ -89,14 +89,18 @@ public abstract class AbstractMessage implements Message {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
 		AbstractMessage that = (AbstractMessage) o;
-		return Objects.equals(content, that.content) && Objects.equals(properties, that.properties) && messageType == that.messageType;
+		return Objects.equals(content, that.content) && Objects.equals(properties, that.properties)
+				&& messageType == that.messageType;
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(content, properties, messageType);
 	}
+
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/chain/AiChainTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chain/AiChainTests.java
@@ -1,0 +1,40 @@
+package org.springframework.ai.chain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.client.AiClient;
+import org.springframework.ai.client.AiResponse;
+import org.springframework.ai.client.Generation;
+import org.springframework.ai.parser.OutputParser;
+import org.springframework.ai.prompt.Prompt;
+import org.springframework.ai.prompt.PromptTemplate;
+import org.springframework.ai.prompt.messages.UserMessage;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AiChainTests {
+
+    @Test
+    public void x() {
+        AiClient aiClient = mock(AiClient.class);
+        Prompt prompt = new Prompt(new UserMessage("Tell me a joke about cows"));
+        AiResponse response = new AiResponse(List.of(new Generation("Why did the cow cross the road? To get to the udder side.")));
+        when(aiClient.generate(prompt)).thenReturn(response);
+
+        // String resource for prompt string
+        PromptTemplate promptTemplate = new PromptTemplate("Tell me a joke about {subject}");
+
+        OutputParser outputParser = mock(OutputParser.class);
+
+        AiChain aiChain = new AiChain(aiClient, promptTemplate, "outdata", outputParser);
+
+        AiInput aiInput = new AiInput(Map.of("subject", "cows"));
+        AiOutput aiOutput = aiChain.apply(aiInput);
+        assertThat(aiOutput.getOutputData().get("outdata")).isEqualTo("Why did the cow cross the road? To get to the udder side.");
+    }
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chain/AiChainTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chain/AiChainTests.java
@@ -19,30 +19,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AiChainTests {
 
-    @Test
-    public void renderPromptAndGenerate() {
-        AiChain aiChain = setupAiChain();
-        AiInput aiInput = new AiInput(Map.of("subject", "cows"));
-        AiOutput aiOutput = aiChain.apply(aiInput);
-        System.err.println(" --> " + aiOutput.getOutputData());
-        assertThat(aiOutput.getOutputData().get("outdata")).isEqualTo("Why did the cow cross the road? To get to the udder side.");
-    }
+	@Test
+	public void renderPromptAndGenerate() {
+		AiChain aiChain = setupAiChain();
+		AiInput aiInput = new AiInput(Map.of("subject", "cows"));
+		AiOutput aiOutput = aiChain.apply(aiInput);
+		System.err.println(" --> " + aiOutput.getOutputData());
+		assertThat(aiOutput.getOutputData().get("outdata"))
+			.isEqualTo("Why did the cow cross the road? To get to the udder side.");
+	}
 
-    @Test
-    public void renderPromptAndGenerateString() {
-        AiChain aiChain = setupAiChain();
-        String generation = aiChain.apply(Map.of("subject", "cows"));
-        assertThat(generation).isEqualTo("Why did the cow cross the road? To get to the udder side.");
-    }
+	@Test
+	public void renderPromptAndGenerateString() {
+		AiChain aiChain = setupAiChain();
+		String generation = aiChain.apply(Map.of("subject", "cows"));
+		assertThat(generation).isEqualTo("Why did the cow cross the road? To get to the udder side.");
+	}
 
-    private static AiChain setupAiChain() {
-        AiClient aiClient = mock(AiClient.class);
-        Prompt prompt = new Prompt(new UserMessage("Tell me a joke about cows"));
-        AiResponse response = new AiResponse(List.of(new Generation("Why did the cow cross the road? To get to the udder side.")));
-        when(aiClient.generate(prompt)).thenReturn(response);
-        PromptTemplate promptTemplate = new PromptTemplate("Tell me a joke about {subject}");
-        OutputParser outputParser = new StringOutputParser();
+	private static AiChain setupAiChain() {
+		AiClient aiClient = mock(AiClient.class);
+		Prompt prompt = new Prompt(new UserMessage("Tell me a joke about cows"));
+		AiResponse response = new AiResponse(
+				List.of(new Generation("Why did the cow cross the road? To get to the udder side.")));
+		when(aiClient.generate(prompt)).thenReturn(response);
+		PromptTemplate promptTemplate = new PromptTemplate("Tell me a joke about {subject}");
+		OutputParser outputParser = new StringOutputParser();
 
-        return new AiChain(aiClient, promptTemplate, "outdata", outputParser);
-    }
+		return new AiChain(aiClient, promptTemplate, "outdata", outputParser);
+	}
+
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/chain/AiChainTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chain/AiChainTests.java
@@ -5,6 +5,7 @@ import org.springframework.ai.client.AiClient;
 import org.springframework.ai.client.AiResponse;
 import org.springframework.ai.client.Generation;
 import org.springframework.ai.parser.OutputParser;
+import org.springframework.ai.parser.StringOutputParser;
 import org.springframework.ai.prompt.Prompt;
 import org.springframework.ai.prompt.PromptTemplate;
 import org.springframework.ai.prompt.messages.UserMessage;
@@ -19,22 +20,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AiChainTests {
 
     @Test
-    public void x() {
+    public void renderPromptAndGenerate() {
+        AiChain aiChain = setupAiChain();
+        AiInput aiInput = new AiInput(Map.of("subject", "cows"));
+        AiOutput aiOutput = aiChain.apply(aiInput);
+        System.err.println(" --> " + aiOutput.getOutputData());
+        assertThat(aiOutput.getOutputData().get("outdata")).isEqualTo("Why did the cow cross the road? To get to the udder side.");
+    }
+
+    @Test
+    public void renderPromptAndGenerateString() {
+        AiChain aiChain = setupAiChain();
+        String generation = aiChain.apply(Map.of("subject", "cows"));
+        assertThat(generation).isEqualTo("Why did the cow cross the road? To get to the udder side.");
+    }
+
+    private static AiChain setupAiChain() {
         AiClient aiClient = mock(AiClient.class);
         Prompt prompt = new Prompt(new UserMessage("Tell me a joke about cows"));
         AiResponse response = new AiResponse(List.of(new Generation("Why did the cow cross the road? To get to the udder side.")));
         when(aiClient.generate(prompt)).thenReturn(response);
-
-        // String resource for prompt string
         PromptTemplate promptTemplate = new PromptTemplate("Tell me a joke about {subject}");
+        OutputParser outputParser = new StringOutputParser();
 
-        OutputParser outputParser = mock(OutputParser.class);
-
-        AiChain aiChain = new AiChain(aiClient, promptTemplate, "outdata", outputParser);
-
-        AiInput aiInput = new AiInput(Map.of("subject", "cows"));
-        AiOutput aiOutput = aiChain.apply(aiInput);
-        assertThat(aiOutput.getOutputData().get("outdata")).isEqualTo("Why did the cow cross the road? To get to the udder side.");
+        return new AiChain(aiClient, promptTemplate, "outdata", outputParser);
     }
-
 }


### PR DESCRIPTION
This chain implementation is roughly equivalent to Langchain's `LLMChain`, although it does not (yet) have asynchronous implementations of its `apply()` methods.

The test shows a basic use of this chain, but note that it can also be declared as a bean...

```
    @Bean
    AiChain llmChain(AiClient aiClient, @Value("classpath:/chat-prompt.st") Resource prompt) {
        PromptTemplate promptTemplate = new PromptTemplate(prompt);
        return new AiChain(
                aiClient,
                promptTemplate,
                "data",
                new StringOutputParser());
    }
```

...and then injected into any bean where it's needed.

Also note that although the `Chain` implementation extends `Function<AiInput, AiOuput>`, which means any implementation must implement `AiOutput apply(AiInput)`, I chose to also override `apply()` with one that takes the input variables as a `Map` and returns a `String` for simpler usage. This is not only a convenience (much like the overridden `generate()` method in `AiClient`), but also is consistent with how Langchain chain implementations have two methods, one that returns `LLMResult` and one that returns a simple string.